### PR TITLE
fix: parse background agent tool calls and tokens from subagent JSONL

### DIFF
--- a/apps/web/src/lib/parsers/types.ts
+++ b/apps/web/src/lib/parsers/types.ts
@@ -240,6 +240,13 @@ export interface RawJsonlMessage {
     totalToolUseCount?: number
     totalDurationMs?: number
     agentId?: string
+    isAsync?: boolean
+    status?: string
+    retrieval_status?: string
+    task?: {
+      task_id?: string
+      status?: string
+    }
   }
   slug?: string
   subtype?: string


### PR DESCRIPTION
## Summary

- Background agents (`run_in_background: true`) didn't show tool calls, tokens, or model info in the dashboard because the parser only extracted agent data from `agent_progress` messages — which don't exist for background agents
- Now extracts `agentId` from the async launch `toolUseResult` and parses the full subagent JSONL file for tokens, tool calls, model, and skills
- Foreground agent data from `agent_progress` messages still takes priority (no regression)

## What changed

**`apps/web/src/lib/parsers/types.ts`** — Expanded `toolUseResult` type to support async launch pattern (`isAsync`, `agentId`, `retrieval_status`, `task`)

**`apps/web/src/lib/parsers/session-parser.ts`** — 4 changes:
1. Extract `agentId` from async tool results (lines 383-391)
2. New `parseSubagentDetail()` function replacing `parseSubagentSkills()` — extracts skills + tokens + tool calls + model in one pass
3. Enhanced agent enrichment: fills missing data from subagent JSONL for background agents, adds tokens to session-level totals
4. `SubagentDetail` interface for the new return type

## Root cause

When agents run in background, the main session JSONL gets zero `agent_progress` messages. The `agentId` (needed to find `subagents/agent-{id}.jsonl`) is only available in the async launch `toolUseResult`, which the parser previously ignored.

## Test plan

- [x] `npm run typecheck` passes
- [ ] Verify background agent sessions now show tool calls, tokens, and model in session detail view
- [ ] Verify foreground agent sessions still display correctly (no regression)
- [ ] Verify sessions with mixed foreground + background agents work

🤖 Generated with [Claude Code](https://claude.com/claude-code)