### PR TITLE
feat: display session resume ID on detail page and cards

### DIFF
--- a/apps/web/package-lock.json
+++ b/apps/web/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "claude-session-dashboard",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "claude-session-dashboard",
-      "version": "0.4.0",
+      "version": "0.4.1",
       "license": "MIT",
       "dependencies": {
         "@tanstack/react-query": "^5.75.0",

--- a/apps/web/src/features/session-detail/SessionIdDisplay.test.tsx
+++ b/apps/web/src/features/session-detail/SessionIdDisplay.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SessionIdDisplay } from './SessionIdDisplay'
+
+describe('SessionIdDisplay', () => {
+  const sessionId = 'f656e46e-bfaa-4997-8b69-d2d955ea2bfc'
+
+  beforeEach(() => {
+    // Mock navigator.clipboard.writeText
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    })
+  })
+
+  it('should render the full session ID', () => {
+    render(<SessionIdDisplay sessionId={sessionId} />)
+    expect(screen.getByText(sessionId)).toBeInTheDocument()
+  })
+
+  it('should have a copy button', () => {
+    render(<SessionIdDisplay sessionId={sessionId} />)
+    const copyButton = screen.getByRole('button')
+    expect(copyButton).toBeInTheDocument()
+  })
+
+  it('should copy resume command to clipboard when button is clicked', () => {
+    render(<SessionIdDisplay sessionId={sessionId} />)
+    const copyButton = screen.getByRole('button')
+
+    fireEvent.click(copyButton)
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      `claude --resume ${sessionId}`
+    )
+  })
+
+  it('should copy resume command exactly once per click', () => {
+    render(<SessionIdDisplay sessionId={sessionId} />)
+    const copyButton = screen.getByRole('button')
+
+    fireEvent.click(copyButton)
+    fireEvent.click(copyButton)
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledTimes(2)
+    expect(navigator.clipboard.writeText).toHaveBeenNthCalledWith(
+      1,
+      `claude --resume ${sessionId}`
+    )
+    expect(navigator.clipboard.writeText).toHaveBeenNthCalledWith(
+      2,
+      `claude --resume ${sessionId}`
+    )
+  })
+
+  it('should handle different session IDs', () => {
+    const differentSessionId = 'abc12345-6789-1234-5678-90abcdef1234'
+    render(<SessionIdDisplay sessionId={differentSessionId} />)
+
+    expect(screen.getByText(differentSessionId)).toBeInTheDocument()
+
+    const copyButton = screen.getByRole('button')
+    fireEvent.click(copyButton)
+
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      `claude --resume ${differentSessionId}`
+    )
+  })
+})

--- a/apps/web/src/features/session-detail/SessionIdDisplay.tsx
+++ b/apps/web/src/features/session-detail/SessionIdDisplay.tsx
@@ -1,0 +1,35 @@
+import { useState, useRef, useEffect } from 'react'
+
+export function SessionIdDisplay({ sessionId }: { sessionId: string }) {
+  const [copied, setCopied] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+  useEffect(() => {
+    return () => clearTimeout(timerRef.current)
+  }, [])
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(`claude --resume ${sessionId}`)
+      setCopied(true)
+      clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard API unavailable -- silently fail
+    }
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1.5 font-mono text-xs text-gray-600">
+      <span>{sessionId}</span>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="rounded px-1 py-0.5 text-gray-500 hover:bg-gray-800 hover:text-gray-300"
+        title="Copy resume command"
+      >
+        {copied ? 'Copied!' : 'Copy'}
+      </button>
+    </span>
+  )
+}

--- a/apps/web/src/features/session-detail/docs.md
+++ b/apps/web/src/features/session-detail/docs.md
@@ -1,0 +1,31 @@
+# Noridoc: session-detail
+
+Path: @/apps/web/src/features/session-detail
+
+### Overview
+
+- Vertical slice for the individual session detail view, containing server data fetching, React Query integration, and all UI panels that render on the session detail page
+- Data flows from `~/.claude/projects/<encoded-path>/<sessionId>.jsonl` through `session-detail.server.ts` -> `session-detail.queries.ts` -> route page and panel components
+- Panels cover context window usage, tool frequency, cost estimation, agent dispatches, tasks, errors, timeline, skills, and the session resume ID display
+
+### How it fits into the larger codebase
+
+- The route at `@/apps/web/src/routes/_dashboard/sessions/$sessionId.tsx` composes these panels into the detail page layout and passes the `SessionDetail` type (defined in `@/apps/web/src/lib/parsers/types.ts`) into each panel
+- `session-detail.server.ts` calls `parseDetail()` from `@/apps/web/src/lib/parsers/session-parser` to transform raw JSONL into a `SessionDetail` object
+- `session-detail.queries.ts` wraps the server function in a `queryOptions` call with adaptive stale/refetch timing based on whether the session is active (2s stale / 5s refetch) or completed (30s stale / no refetch)
+- Cost estimation panels (`CostEstimationPanel`, `CostSummaryLine`) are imported from `@/apps/web/src/features/cost-estimation/`
+- Active session detection is shared from `@/apps/web/src/features/sessions/useIsSessionActive.ts`
+
+### Core Implementation
+
+- **Server function:** `getSessionDetail` in `session-detail.server.ts` resolves the sessionId to a JSONL file path by searching `~/.claude/projects/` directories, first by matching `projectPath`, then by exhaustive fallback search
+- **Query layer:** `sessionDetailQuery()` in `session-detail.queries.ts` takes `sessionId`, `projectPath`, and `isActive` to configure React Query caching behavior
+- **SessionIdDisplay component:** Renders the full session UUID with a "Copy" button that writes `claude --resume <sessionId>` to the clipboard via `navigator.clipboard.writeText()`. Uses local `useState` to show a 2-second "Copied!" confirmation
+
+### Things to Know
+
+- The `findSessionFile` function in `session-detail.server.ts` uses a two-pass search: first matching the provided `projectPath` against decoded directory names, then falling back to scanning all project directories for the JSONL file
+- `SessionIdDisplay` copies the full `claude --resume <UUID>` command (not just the UUID) to make session resumption a single paste operation
+- The route page (`$sessionId.tsx`) computes `durationMs` from the first and last turn timestamps, rather than receiving it pre-computed from the server
+
+Created and maintained by Nori.

--- a/apps/web/src/features/sessions/SessionCard.test.tsx
+++ b/apps/web/src/features/sessions/SessionCard.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SessionCard } from './SessionCard'
+import { PrivacyProvider } from '@/features/privacy/PrivacyContext'
+import type { SessionSummary } from '@/lib/parsers/types'
+
+// Mock @tanstack/react-router Link component
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+}))
+
+describe('SessionCard', () => {
+  const mockSession: SessionSummary = {
+    sessionId: 'f656e46e-bfaa-4997-8b69-d2d955ea2bfc',
+    projectPath: '/Users/test/projects/my-app',
+    projectName: 'my-app',
+    branch: 'feature/test-branch',
+    cwd: '/Users/test/projects/my-app',
+    startedAt: '2026-02-25T10:00:00.000Z',
+    lastActiveAt: '2026-02-25T11:30:00.000Z',
+    durationMs: 5400000,
+    messageCount: 42,
+    userMessageCount: 21,
+    assistantMessageCount: 21,
+    isActive: false,
+    model: 'claude-sonnet-4-5-20250929',
+    version: '0.4.1',
+    fileSizeBytes: 102400,
+  }
+
+  it('should render truncated session ID (first 8 characters)', () => {
+    render(
+      <PrivacyProvider>
+        <SessionCard session={mockSession} />
+      </PrivacyProvider>
+    )
+
+    // The first 8 characters of sessionId should be visible
+    const truncatedId = mockSession.sessionId.slice(0, 8)
+    expect(screen.getByText(truncatedId)).toBeInTheDocument()
+  })
+
+  it('should not render the full session ID', () => {
+    const { container } = render(
+      <PrivacyProvider>
+        <SessionCard session={mockSession} />
+      </PrivacyProvider>
+    )
+
+    expect(container.textContent).not.toContain(mockSession.sessionId)
+  })
+
+  it('should render session ID alongside other session info', () => {
+    render(
+      <PrivacyProvider>
+        <SessionCard session={mockSession} />
+      </PrivacyProvider>
+    )
+
+    // Verify truncated session ID is present
+    const truncatedId = mockSession.sessionId.slice(0, 8)
+    expect(screen.getByText(truncatedId)).toBeInTheDocument()
+
+    // Verify other info still renders
+    expect(screen.getByText('my-app')).toBeInTheDocument()
+    expect(screen.getByText(/42 msgs/)).toBeInTheDocument()
+  })
+})

--- a/apps/web/src/features/sessions/SessionCard.tsx
+++ b/apps/web/src/features/sessions/SessionCard.tsx
@@ -60,6 +60,9 @@ export function SessionCard({ session }: { session: SessionSummary }) {
         <span title="File size" className="text-gray-500">
           {formatBytes(session.fileSizeBytes)}
         </span>
+        <span title="Session ID" className="font-mono text-gray-500">
+          {session.sessionId.slice(0, 8)}
+        </span>
       </div>
 
       {displayCwd && (

--- a/apps/web/src/features/sessions/docs.md
+++ b/apps/web/src/features/sessions/docs.md
@@ -1,0 +1,31 @@
+# Noridoc: sessions
+
+Path: @/apps/web/src/features/sessions
+
+### Overview
+
+- Vertical slice for the session list view, handling server-side scanning, pagination/filtering, and the card-based UI for browsing all Claude Code sessions
+- Data flows from `~/.claude/projects/` through the scanner (`@/apps/web/src/lib/scanner/session-scanner`) -> server functions -> React Query -> `SessionList` -> `SessionCard` components
+- Provides active session detection shared by other features
+
+### How it fits into the larger codebase
+
+- The route at `@/apps/web/src/routes/_dashboard/sessions/index.tsx` renders `SessionList`, which is the primary consumer of this feature slice
+- `sessions.server.ts` exposes three server functions: `getSessionList` (all sessions), `getActiveSessionList` (active only, fast-polling), and `getPaginatedSessions` (filtered/paginated)
+- `SessionCard` links to the session detail route at `@/apps/web/src/routes/_dashboard/sessions/$sessionId.tsx`, passing `sessionId` and `projectPath` as route params/search
+- `useIsSessionActive` is consumed by the session detail feature (`@/apps/web/src/features/session-detail/`) to adjust query refetch intervals
+- Privacy mode support comes from `@/apps/web/src/features/privacy/PrivacyContext`, applied to project names, branches, and paths in the card display
+
+### Core Implementation
+
+- **SessionList** merges two queries: a paginated session query (30s refetch) and an active sessions query (3s refetch), combining them so active status stays current even when the paginated data is stale
+- **SessionCard** renders a clickable card with project name, branch, duration/timer, message count, model, file size, and a truncated 8-character session ID. The session ID uses `sessionId.slice(0, 8)` for compact display in the metadata row
+- **Pagination logic** in `sessions.server.ts` (`paginateAndFilterSessions`) applies search (substring match on projectName/branch/sessionId/cwd), status filter, and project filter before slicing to the requested page
+- **Page size preference** is persisted to localStorage via `usePageSizePreference` and applied on mount with URL-param-takes-priority semantics
+
+### Things to Know
+
+- The search filter in `paginateAndFilterSessions` matches against `sessionId`, which means users can search for sessions by their UUID
+- Active session merging in `SessionList` uses a `Set` of active session IDs to override `isActive` on stale paginated results, preventing active sessions from appearing inactive between paginated refetches
+
+Created and maintained by Nori.

--- a/apps/web/src/routes/_dashboard/sessions/$sessionId.tsx
+++ b/apps/web/src/routes/_dashboard/sessions/$sessionId.tsx
@@ -14,6 +14,7 @@ import { useIsSessionActive } from '@/features/sessions/useIsSessionActive'
 import { formatDuration, formatDateTime } from '@/lib/utils/format'
 import { sessionToJSON, downloadFile } from '@/lib/utils/export-utils'
 import { ExportDropdown } from '@/components/ExportDropdown'
+import { SessionIdDisplay } from '@/features/session-detail/SessionIdDisplay'
 import { usePrivacy } from '@/features/privacy/PrivacyContext'
 import { z } from 'zod'
 
@@ -123,9 +124,7 @@ function SessionDetailPage() {
               },
             ]}
           />
-          <span className="font-mono text-xs text-gray-600">
-            {sessionId.slice(0, 8)}
-          </span>
+          <SessionIdDisplay sessionId={sessionId} />
         </div>
       </div>
 

--- a/apps/web/src/routes/_dashboard/sessions/docs.md
+++ b/apps/web/src/routes/_dashboard/sessions/docs.md
@@ -1,0 +1,28 @@
+# Noridoc: sessions routes
+
+Path: @/apps/web/src/routes/_dashboard/sessions
+
+### Overview
+
+- File-based TanStack Router routes for the sessions section of the dashboard
+- Contains the session list page (`index.tsx`) and the session detail page (`$sessionId.tsx`)
+- These routes are thin wrappers that validate URL params/search and compose feature-slice components
+
+### How it fits into the larger codebase
+
+- Lives under the `_dashboard` layout route, which provides the shared dashboard shell
+- `index.tsx` renders `SessionList` from `@/apps/web/src/features/sessions/`
+- `$sessionId.tsx` composes panels from `@/apps/web/src/features/session-detail/` (ContextWindowPanel, ToolUsagePanel, ErrorPanel, AgentDispatchesPanel, TasksPanel, TimelineEventsChart, SkillInvocationsPanel, SessionIdDisplay) and `@/apps/web/src/features/cost-estimation/` (CostEstimationPanel, CostSummaryLine)
+- Search params are validated with Zod schemas: the list page accepts `page`, `pageSize`, `search`, `status`, and `project`; the detail page accepts `project`
+
+### Core Implementation
+
+- **Session list route** (`index.tsx`): Validates search params via `sessionsSearchSchema` with defaults (page 1, pageSize 5, empty search, status "all", empty project), then renders `SessionList`
+- **Session detail route** (`$sessionId.tsx`): Extracts `sessionId` from URL params and `project` from search params. Fetches `SessionDetail` via `sessionDetailQuery`, computing duration from first/last turn timestamps. The header displays project name, branch, datetime, duration, turn count, cost summary, model badges, an export dropdown, and the full session UUID with a copy button (`SessionIdDisplay`)
+
+### Things to Know
+
+- The detail page uses `useIsSessionActive` to drive both an `ActiveSessionBanner` and the refetch interval of the detail query -- active sessions poll at 5s
+- Privacy mode (from `@/apps/web/src/features/privacy/PrivacyContext`) is applied in both routes to anonymize project names and branches
+
+Created and maintained by Nori.

--- a/apps/web/src/test/docs.md
+++ b/apps/web/src/test/docs.md
@@ -1,0 +1,28 @@
+# Noridoc: test
+
+Path: @/apps/web/src/test
+
+### Overview
+
+- Vitest test infrastructure: global setup and type declarations for the test environment
+- Provides browser API mocks (localStorage, clipboard) and custom matchers needed by component tests across the app
+
+### How it fits into the larger codebase
+
+- `setup.ts` is referenced as the Vitest `setupFiles` entry, running before every test file in the project
+- `vitest.d.ts` augments the Vitest `Assertion` and `AsymmetricMatchersContaining` interfaces so TypeScript recognizes custom matchers like `toBeInTheDocument()`
+- Component tests throughout `@/apps/web/src/features/` depend on the mocks and matchers configured here
+
+### Core Implementation
+
+- **Custom `toBeInTheDocument` matcher:** Checks `document.body.contains(received)`, providing a lightweight alternative to `@testing-library/jest-dom` for DOM presence assertions
+- **localStorage mock:** A `LocalStorageMock` class implementing the full `Storage` interface, assigned to `window.localStorage` via `Object.defineProperty`
+- **Clipboard mock:** Makes `navigator.clipboard` writable and configurable so individual tests can replace `writeText` with a `vi.fn()` via `Object.assign`. The default stub is a no-op async function
+- **Cleanup:** `beforeEach` clears localStorage and calls `@testing-library/react`'s `cleanup()` to unmount rendered components between tests
+
+### Things to Know
+
+- `navigator.clipboard` is defined with `writable: true` and `configurable: true` specifically so tests like `SessionIdDisplay.test.tsx` can override it with `Object.assign(navigator, { clipboard: { writeText: vi.fn() } })` per test suite
+- The custom `toBeInTheDocument` matcher is a manual implementation, not from `@testing-library/jest-dom` -- the corresponding type declaration in `vitest.d.ts` makes it available to TypeScript without installing that package
+
+Created and maintained by Nori.

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -53,6 +53,15 @@ if (typeof window !== 'undefined') {
   })
 }
 
+// Make navigator.clipboard writable so tests can mock it via Object.assign
+if (typeof navigator !== 'undefined') {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: async () => {} },
+    writable: true,
+    configurable: true,
+  })
+}
+
 // Clear localStorage and cleanup after each test
 beforeEach(() => {
   if (typeof window !== 'undefined' && window.localStorage) {

--- a/apps/web/src/test/vitest.d.ts
+++ b/apps/web/src/test/vitest.d.ts
@@ -1,0 +1,12 @@
+import 'vitest'
+
+declare module 'vitest' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface Assertion<T = unknown> {
+    toBeInTheDocument(): T
+  }
+  // eslint-disable-next-line @typescript-eslint/no-empty-object-type
+  interface AsymmetricMatchersContaining {
+    toBeInTheDocument(): unknown
+  }
+}


### PR DESCRIPTION
## Summary
🤖 Generated with [Nori](https://www.npmjs.com/package/nori-ai)

- Display the `claude --resume <UUID>` session ID on the session detail page with a copy-to-clipboard button that copies the full resume command
- Show truncated session ID (first 8 chars) on session list cards in the metadata row
- New `SessionIdDisplay` component with proper clipboard error handling and timeout cleanup

## Test Plan
- [x] SessionCard renders truncated session ID (8 chars)
- [x] SessionIdDisplay renders full UUID with copy button
- [x] Copy button writes `claude --resume <UUID>` to clipboard
- [x] All 240 tests pass
- [x] Typecheck clean
- [x] Lint clean (0 errors)

Share Nori with your team: https://www.npmjs.com/package/nori-ai