### PR TITLE
chore: skip expensive CI workflows for Dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,9 @@ updates:
       interval: "weekly"
       day: "monday"
     open-pull-requests-limit: 10
+    ignore:
+      - dependency-name: "eslint"
+        update-types: ["version-update:semver-major"]
     groups:
       # Group minor and patch updates together
       production-dependencies:

--- a/.github/workflows/clusterfuzzlite.yml
+++ b/.github/workflows/clusterfuzzlite.yml
@@ -35,7 +35,7 @@ jobs:
   fuzz-pr:
     name: Fuzz (pull request)
     runs-on: ubuntu-latest
-    if: github.event_name == 'pull_request'
+    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
     needs: build
     continue-on-error: true
     permissions:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,6 +15,7 @@ jobs:
   analyze:
     name: Analyze
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     permissions:
       actions: read
       contents: read

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -12,6 +12,7 @@ jobs:
   eslint:
     name: ESLint Review
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -38,6 +39,7 @@ jobs:
   pr-size-label:
     name: Label PR Size
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/welcome.yml
+++ b/.github/workflows/welcome.yml
@@ -13,6 +13,7 @@ permissions:
 jobs:
   welcome:
     runs-on: ubuntu-latest
+    if: github.actor != 'dependabot[bot]'
     steps:
       - uses: actions/first-interaction@1c4688942c71f71d4f5502a26ea67c331730fa4d # v3
         with:


### PR DESCRIPTION
## Summary

- Added `if: github.actor != 'dependabot[bot]'` to the `eslint` and `pr-size-label` jobs in `pr-review.yml` — inline ESLint reviews and size labels are not useful on bot dependency PRs
- Added `if: github.actor != 'dependabot[bot]'` to the `welcome` job in `welcome.yml` — bots do not need welcome messages
- Added `if: github.actor != 'dependabot[bot]'` to the `analyze` job in `codeql.yml` — CodeQL already runs on push to main and on a weekly schedule, making the PR trigger redundant for Dependabot
- Updated the `fuzz-pr` job condition in `clusterfuzzlite.yml` to also exclude Dependabot PRs
- Added an ignore rule in `dependabot.yml` to block major-version bumps of `eslint`, preventing a repeat of the eslint v10 breakage (eslint-plugin-react-hooks@7 only supports ESLint ≤9)

## Test plan

- [ ] Open a Dependabot PR after merging and confirm PR Review, Welcome, CodeQL (PR trigger), and ClusterFuzzLite fuzz-pr jobs are all skipped
- [ ] Open a human-authored PR and confirm all those workflows still run normally
- [ ] Verify Dependabot no longer proposes eslint major version upgrades