### PR TITLE
chore: gitignore docs/designs and docs/plans folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,6 @@ coverage/
 blob-report/
 **/e2e/screenshots/
 docs/marketing/
+docs/designs/
+docs/plans/
 scripts/


### PR DESCRIPTION
## Summary
- Adds `docs/designs/` and `docs/plans/` to `.gitignore`
- These are transient agent-generated artifacts (design docs, implementation plans) that should not be tracked in git

## Test plan
- [ ] Verify `docs/designs/` and `docs/plans/` are no longer shown as untracked by `git status`