### PR TITLE
feat: display session resume ID with copy-to-clipboard

### DIFF
--- a/apps/web/src/features/session-detail/SessionIdDisplay.test.tsx
+++ b/apps/web/src/features/session-detail/SessionIdDisplay.test.tsx
@@ -1,0 +1,33 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SessionIdDisplay } from './SessionIdDisplay'
+
+describe('SessionIdDisplay', () => {
+  const sessionId = 'f656e46e-bfaa-4997-8b69-d2d955ea2bfc'
+
+  beforeEach(() => {
+    Object.assign(navigator, {
+      clipboard: {
+        writeText: vi.fn().mockResolvedValue(undefined),
+      },
+    })
+  })
+
+  it('renders the full session ID', () => {
+    render(<SessionIdDisplay sessionId={sessionId} />)
+    expect(screen.getByText(sessionId)).toBeTruthy()
+  })
+
+  it('has a copy button', () => {
+    render(<SessionIdDisplay sessionId={sessionId} />)
+    expect(screen.getByRole('button')).toBeTruthy()
+  })
+
+  it('copies resume command to clipboard on click', () => {
+    render(<SessionIdDisplay sessionId={sessionId} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(navigator.clipboard.writeText).toHaveBeenCalledWith(
+      `claude --resume ${sessionId}`
+    )
+  })
+})

--- a/apps/web/src/features/session-detail/SessionIdDisplay.tsx
+++ b/apps/web/src/features/session-detail/SessionIdDisplay.tsx
@@ -1,0 +1,39 @@
+import { useState, useRef, useEffect } from 'react'
+
+interface SessionIdDisplayProps {
+  sessionId: string
+}
+
+export function SessionIdDisplay({ sessionId }: SessionIdDisplayProps) {
+  const [copied, setCopied] = useState(false)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined)
+
+  useEffect(() => {
+    return () => clearTimeout(timerRef.current)
+  }, [])
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(`claude --resume ${sessionId}`)
+      setCopied(true)
+      clearTimeout(timerRef.current)
+      timerRef.current = setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard API unavailable — silently fail
+    }
+  }
+
+  return (
+    <span className="inline-flex items-center gap-1.5 font-mono text-xs text-gray-600">
+      <span>{sessionId}</span>
+      <button
+        type="button"
+        onClick={handleCopy}
+        className="rounded px-1 py-0.5 text-gray-500 hover:bg-gray-800 hover:text-gray-300"
+        title="Copy resume command"
+      >
+        {copied ? 'Copied!' : 'Copy'}
+      </button>
+    </span>
+  )
+}

--- a/apps/web/src/features/sessions/SessionCard.test.tsx
+++ b/apps/web/src/features/sessions/SessionCard.test.tsx
@@ -1,0 +1,49 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SessionCard } from './SessionCard'
+import { PrivacyProvider } from '@/features/privacy/PrivacyContext'
+import type { SessionSummary } from '@/lib/parsers/types'
+
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, className }: { children: React.ReactNode; className?: string }) => (
+    <div className={className}>{children}</div>
+  ),
+}))
+
+describe('SessionCard', () => {
+  const mockSession: SessionSummary = {
+    sessionId: 'f656e46e-bfaa-4997-8b69-d2d955ea2bfc',
+    projectPath: '/Users/test/projects/my-app',
+    projectName: 'my-app',
+    branch: 'feature/test-branch',
+    cwd: '/Users/test/projects/my-app',
+    startedAt: '2026-02-25T10:00:00.000Z',
+    lastActiveAt: '2026-02-25T11:30:00.000Z',
+    durationMs: 5400000,
+    messageCount: 42,
+    userMessageCount: 21,
+    assistantMessageCount: 21,
+    isActive: false,
+    model: 'claude-sonnet-4-5-20250929',
+    version: '0.4.1',
+    fileSizeBytes: 102400,
+  }
+
+  it('renders truncated session ID (first 8 characters)', () => {
+    render(
+      <PrivacyProvider>
+        <SessionCard session={mockSession} />
+      </PrivacyProvider>
+    )
+    expect(screen.getByText(mockSession.sessionId.slice(0, 8))).toBeTruthy()
+  })
+
+  it('does not render the full session ID', () => {
+    const { container } = render(
+      <PrivacyProvider>
+        <SessionCard session={mockSession} />
+      </PrivacyProvider>
+    )
+    expect(container.textContent).not.toContain(mockSession.sessionId)
+  })
+})

--- a/apps/web/src/features/sessions/SessionCard.tsx
+++ b/apps/web/src/features/sessions/SessionCard.tsx
@@ -60,6 +60,9 @@ export function SessionCard({ session }: { session: SessionSummary }) {
         <span title="File size" className="text-gray-500">
           {formatBytes(session.fileSizeBytes)}
         </span>
+        <span title="Session ID" className="font-mono text-gray-500">
+          {session.sessionId.slice(0, 8)}
+        </span>
       </div>
 
       {displayCwd && (

--- a/apps/web/src/routes/_dashboard/sessions/$sessionId.tsx
+++ b/apps/web/src/routes/_dashboard/sessions/$sessionId.tsx
@@ -14,6 +14,7 @@ import { useIsSessionActive } from '@/features/sessions/useIsSessionActive'
 import { formatDuration, formatDateTime } from '@/lib/utils/format'
 import { sessionToJSON, downloadFile } from '@/lib/utils/export-utils'
 import { ExportDropdown } from '@/components/ExportDropdown'
+import { SessionIdDisplay } from '@/features/session-detail/SessionIdDisplay'
 import { usePrivacy } from '@/features/privacy/PrivacyContext'
 import { z } from 'zod'
 
@@ -123,9 +124,7 @@ function SessionDetailPage() {
               },
             ]}
           />
-          <span className="font-mono text-xs text-gray-600">
-            {sessionId.slice(0, 8)}
-          </span>
+          <SessionIdDisplay sessionId={sessionId} />
         </div>
       </div>
 

--- a/apps/web/src/test/setup.ts
+++ b/apps/web/src/test/setup.ts
@@ -53,6 +53,15 @@ if (typeof window !== 'undefined') {
   })
 }
 
+// Make navigator.clipboard writable so tests can mock it via Object.assign
+if (typeof navigator !== 'undefined') {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: async () => {} },
+    writable: true,
+    configurable: true,
+  })
+}
+
 // Clear localStorage and cleanup after each test
 beforeEach(() => {
   if (typeof window !== 'undefined' && window.localStorage) {


### PR DESCRIPTION
## Summary
- Replaces the static truncated session ID on the detail page header with a full UUID + **Copy** button that writes `claude --resume <UUID>` to clipboard
- Shows truncated 8-char session ID in the `SessionCard` metadata row for quick reference
- Adds clipboard mock to test setup and 5 new tests covering both components

## Changes
- New `SessionIdDisplay` component — full UUID display with 2s copy confirmation and timeout cleanup on unmount
- `$sessionId.tsx` — replaces `sessionId.slice(0, 8)` span with `SessionIdDisplay`
- `SessionCard.tsx` — adds `session.sessionId.slice(0, 8)` to the metadata row
- `test/setup.ts` — adds writable clipboard mock for component tests

Inspired by PR #48 from @natealmeida.